### PR TITLE
Publish to TestPYPI, PYPY in separate jobs.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,25 +33,39 @@ jobs:
         path: dist/*
         retention-days: 5
 
+  # todo- uncomment after
+  # https://github.com/tmarktaylor/phmutest/commit/174411e70201c549eb4eb36a1efa5cae26306e90
+  # is published to PYPI.
+  # publish-test-pypi:
+  #   needs: builddist
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     # IMPORTANT this permission is mandatory for trusted publishing
+  #     id-token: write
+
+  #   steps:
+  #   - uses: actions/download-artifact@v4
+  #     with:
+  #       name: dist-${{ env.ref }}
+  #       path: dist
+  #   - name: Publish to Test PYPI
+  #     uses: pypa/gh-action-pypi-publish@release/v1
+  #     with:
+  #       repository-url: https://test.pypi.org/legacy/
+  #       print-hash: true
+
   publish-pypi:
     needs: builddist
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT this permission is mandatory for trusted publishing
       id-token: write
-    steps:
 
+    steps:
     - uses: actions/download-artifact@v4
       with:
         name: dist-${{ env.ref }}
         path: dist
-
-    - name: Publish to Test PYPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        print-hash: true
-
     - name: Publish to PYPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
Also comment out the publish to Test PYPI for v0.1.0 since it has already succeeded.  Once the ref is published another commit can restore the publish-test-pypi: job.